### PR TITLE
Addition of Advert ID to Advert Search results

### DIFF
--- a/AdvertsAPI/__init__.py
+++ b/AdvertsAPI/__init__.py
@@ -26,6 +26,7 @@ class AdvertsAPI:
     __county_tag = "div[class='location'] > a"
     __category_tag = "div[class='location'] > a"
     __url_tag = "div[class='price'] > a"
+    __advert_id = "button"
 
     def __init__(self, category=None, county=None, min_price=0, max_price=0, view='grid_view', search=None):
         super().__init__()
@@ -145,7 +146,8 @@ class AdvertsAPI:
                     panel.select(self.__area_Tag)[0].text.strip(), 
                     panel.select(self.__county_tag)[1].text.strip(), 
                     panel.select(self.__category_tag)[0]['href'].split('/')[2:-4], 
-                    f"""https://adverts.ie{panel.select(self.__url_tag)[0]['href']}"""
+                    f"""https://adverts.ie{panel.select(self.__url_tag)[0]['href']}""",
+                    panel.select(self.__advert_id)[0]['data-ad-id']
                             )
                     )
 

--- a/AdvertsAPI/product_info.py
+++ b/AdvertsAPI/product_info.py
@@ -1,5 +1,5 @@
 class ProductInfo:
-    def __init__(self, price, title, area, county, category, url):
+    def __init__(self, price, title, area, county, category, url, advert_id):
         super().__init__()
         self.__price = price
         self.__title = title
@@ -7,6 +7,7 @@ class ProductInfo:
         self.__county = county
         self.__category = category
         self.__url = url
+        self.__advert_id = advert_id
     
     @property
     def price(self):
@@ -31,3 +32,7 @@ class ProductInfo:
     @property
     def url(self):
         return self.__url
+    
+    @property
+    def advert_id(self):
+        return self.__advert_id


### PR DESCRIPTION
I've added the Adverts Advert ID (say that three times fast) to the `ProductInfo` object returned in search results.
It is useful to determine if you have seen that item before.